### PR TITLE
fix(mailer): handle send failures and notify admins individually

### DIFF
--- a/app/integrations/mailer.py
+++ b/app/integrations/mailer.py
@@ -35,19 +35,24 @@ class Mailer(object):
         :return: Response from the SMTP2GO API
         """
 
-        headers = {"accept": "application/json", "Content-Type": "application/json"}
-        payload = {
-            "api_key": self.api_key,
-            "to": recipients,
-            "sender": sender,
-            "subject": subject,
-            "text_body": text if not html else None,
-            "html_body": text if html else None,
-        }
+        try:
+            headers = {"accept": "application/json", "Content-Type": "application/json"}
+            payload = {
+                "api_key": self.api_key,
+                "to": recipients,
+                "sender": sender,
+                "subject": subject,
+                "text_body": text if not html else None,
+                "html_body": text if html else None,
+            }
 
-        response = requests.post(self.api_url, headers=headers, json=payload)
-        response.raise_for_status()  # Raise an exception for HTTP errors
-        return response.json()
+            response = requests.post(self.api_url, headers=headers, json=payload)
+            response.raise_for_status()  # Raise an exception for HTTP errors
+            
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            print(f"Failed to send email: {e}")
+            return None
 
 
 mailer = Mailer()

--- a/app/routes.py
+++ b/app/routes.py
@@ -50,17 +50,20 @@ def contact_us(json_data):
 
     contact_html = mailer.generate_email_text("new_contact.html", data)
 
-    mailer.send_email(
-        [
-            "support@wedidtech.com",
-            "info@wedidtech.com",
+    admins = [
+            "russellrandyedwin@gmail.com"
             "sg.apawu@gmail.com",
             "joseph3241@gmail.com",
-        ],
-        "We Have A New Contact!",
-        contact_html,
-        html=contact_html,
-    )
+            "jaytaser@gmail.com",
+        ]
+    
+    for admin in admins:
+        mailer.send_email(
+            [admin],
+            "We Have A New Contact!",
+            contact_html,
+            html=contact_html,
+        )
     return success_response()
 
 


### PR DESCRIPTION
Wrap SMTP2GO requests in a `try/except` block to catch `RequestException`, log send failures, and return `None` instead of raising unhandled errors. Also update contact notifications to iterate through an explicit admin list and send each email separately, improving delivery reliability and recipient control.fix(mailer): handle send failures and notify admins individually

Wrap SMTP2GO requests in a `try/except` block to catch `RequestException`, log send failures, and return `None` instead of raising unhandled errors. Also update contact notifications to iterate through an explicit admin list and send each email separately, improving delivery reliability and recipient control.